### PR TITLE
BUG: Define GetOutput() for Python wrapping

### DIFF
--- a/include/itkElastixRegistrationMethod.h
+++ b/include/itkElastixRegistrationMethod.h
@@ -169,6 +169,10 @@ public:
   GetOutput(unsigned int idx);
   const DataObject *
   GetOutput(unsigned int idx) const;
+  ResultImageType *
+  GetOutput();
+  ResultImageType *
+  GetOutput() const;
 
   /* Standard filter indexed input / output methods */
   void

--- a/include/itkElastixRegistrationMethod.hxx
+++ b/include/itkElastixRegistrationMethod.hxx
@@ -351,6 +351,22 @@ ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetTransformParameterObjec
 
 
 template <typename TFixedImage, typename TMovingImage>
+typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::ResultImageType *
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetOutput()
+{
+  return static_cast<ResultImageType *>(this->ProcessObject::GetOutput(0));
+}
+
+
+template <typename TFixedImage, typename TMovingImage>
+const typename ElastixRegistrationMethod<TFixedImage, TMovingImage>::ResultImageType *
+ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetOutput() const
+{
+  return static_cast<const ResultImageType *>(this->ProcessObject::GetOutput(0));
+}
+
+
+template <typename TFixedImage, typename TMovingImage>
 DataObject *
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::GetOutput(unsigned int idx)
 {


### PR DESCRIPTION
Explicitly define GetOutput() for Python wrapping without the index and
with the ResultImageType as a return type.