### PR TITLE
Update example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To register two images, traditionally called the fixed image and the moving imag
     fixed_image = itk.imread('path/to/fixed_image.mha')
     moving_image = itk.imread('path/to/moving_image.mha')
 
-    registered_image = itk.elastix_registration_method(fixed_image, moving_image)
+    registered_image, params = itk.elastix_registration_method(fixed_image, moving_image)
 
 Interactive examples and tutorial material can be found in the [examples](https://github.com/InsightSoftwareConsortium/ITKElastix/tree/master/examples) directory. Run the examples in free cloud compute containers [on MyBinder](https://mybinder.org/v2/gh/InsightSoftwareConsortium/ITKElastix/master?urlpath=lab/tree/examples%2F0_HelloRegistrationWorld.ipynb).  Try out the *experimental* GPU packages [on Paperspace Gradient](https://www.paperspace.com/temmx3m64/notebook/prdfn7bsz).
 


### PR DESCRIPTION
I tried to follow the example and ran into this error message:

```
RuntimeError: No suitable template parameter can be found.
```

Turns out `itk.elastix_registration_method` returns a tuple:

```
(<itk.itkImagePython.itkImageF2; proxy of <Swig Object of type 'itkImageF2 *' at 0x7f248994abd0> >, <itk.elxParameterObjectPython.elastixParameterObject; proxy of <Swig Object of type 'elastixParameterObject *' at 0x7f248994aba0> >)
```

And that error message popped up when I passed the tuple to `sitk.array_from_image`. I guess adding `params` will remind people what they get from this function call.

I'm running `itk` 5.1.0.post3 and `itk-elastix` 0.6.2