### PR TITLE
ENH: Switch to latest version of SuperElastix/elastix (using ITK 5.1.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(DEFINED ENV{ELASTIX_USE_OPENCL})
   set(ELASTIX_USE_OPENCL ON CACHE BOOL "Enable OpenCL support in Elastix")
 endif()
 
-set(Elastix_LIBRARIES elastix transformix)
+set(Elastix_LIBRARIES elastix_lib transformix_lib)
 if(ELASTIX_USE_OPENCL)
   list(APPEND Elastix_LIBRARIES elxOpenCL)
 endif()
@@ -39,8 +39,9 @@ set(_itk_build_testing ${BUILD_TESTING})
 #set(BUILD_TESTING OFF)
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
-set(elastix_GIT_REPOSITORY "https://github.com/thewtex/elastix.git")
-set(elastix_GIT_TAG "a13be5c2daa1d2b8454609366aef3cba194be8c2")
+set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
+# Tag of commit "COMP: Fix implicit conversion warnings itkAdvancedImageMomentsCalculator"
+set(elastix_GIT_TAG "a7e4fb99954f18eb34a65d60acc8ea1f1a5eeb12")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}

--- a/include/itkElastixRegistrationMethod.hxx
+++ b/include/itkElastixRegistrationMethod.hxx
@@ -44,7 +44,6 @@ namespace itk
 template <typename TFixedImage, typename TMovingImage>
 ElastixRegistrationMethod<TFixedImage, TMovingImage>::ElastixRegistrationMethod()
 {
-  elastix::BaseComponent::InitializeElastixLibrary();
   this->SetPrimaryInputName("FixedImage");
   this->SetNumberOfIndexedOutputs(2);
 

--- a/include/itkTransformixFilter.hxx
+++ b/include/itkTransformixFilter.hxx
@@ -44,8 +44,6 @@ namespace itk
 template <typename TMovingImage>
 TransformixFilter<TMovingImage>::TransformixFilter()
 {
-  elastix::BaseComponent::InitializeElastixLibrary();
-
   this->SetPrimaryInputName("TransformParameterObject");
   this->SetPrimaryOutputName("ResultImage");
   this->SetOutput("ResultDeformationField", this->MakeOutput("ResultDeformationField"));


### PR DESCRIPTION
Removed obsolete `elastix::BaseComponent::InitializeElastixLibrary()`
calls, as Elastix is now initialized as a library by default:
"ENH: Replace InitializeElastixLibrary() by InitializeElastixExecutable()"
https://github.com/SuperElastix/elastix/pull/248
https://github.com/SuperElastix/elastix/commit/ef64fb26abcb23a21f7010b5b58f0d732431f8a8

Adjusted CMake `Elastix_LIBRARIES`, as the Elastix library CMake targets
are now named elastix_lib and transformix_lib:
"ENH: Allow building exe and lib of elastix and transformix together"
https://github.com/SuperElastix/elastix/pull/232
https://github.com/SuperElastix/elastix/commit/3944a13d8dcbe9fcc33cf348f25a1d4f59d79cd7