### PR TITLE
COMP: Update elastix to address macOS dangling-gsl warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(_itk_build_testing ${BUILD_TESTING})
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "1f973ae9bc2ef551f984ad7df35167e266e55ee0")
+set(elastix_GIT_TAG "e72d2b690d0a0d869ec89cb9bd444a450d21bf88")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}


### PR DESCRIPTION
Incorporates:

- https://github.com/SuperElastix/elastix/issues/355
- https://github.com/SuperElastix/elastix/pull/356