### PR TITLE
COMP: Update CI for GitHub macOS runner 10.15 changes

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "v5.1.2"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "v5.1.2"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "v5.1.2"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -38,6 +38,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ninja
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: Download ITK
       run: |
@@ -170,10 +173,17 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.1.2"
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: 'Specific XCode version'
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: 'Fetch build script'
       run: |
@@ -199,9 +209,12 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.1.2"
 
     steps:
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - uses: actions/checkout@v2
       with:
         path: "im"
@@ -245,9 +258,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [35, 36, 37, 38]
+        python-version: [36, 37, 38]
         include:
-          - itk-python-git-tag: "v5.1.1"
+          - itk-python-git-tag: "v5.1.2"
 
     steps:
     - uses: actions/checkout@v2
@@ -279,10 +292,13 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.1.2"
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: 'Fetch build script'
       run: |


### PR DESCRIPTION
For more information on the required changes, see:

- https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/pull/98
- https://github.com/InsightSoftwareConsortium/ITK/issues/2162

This has the side effect of updating ITKElastix to be based ITK 5.1.2.