### PR TITLE
ENH: Build with 4D elastix support

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "abd38d5a0040b9a8fbb0ad3127089dbb72a93342"
+            itk-git-tag: "v5.2rc02"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -137,7 +137,7 @@ jobs:
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc02"
 
     steps:
     - uses: actions/checkout@v2
@@ -173,7 +173,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc02"
 
     steps:
     - uses: actions/checkout@v2
@@ -209,7 +209,7 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.2rc02"
 
     steps:
     - name: Get specific version of CMake, Ninja
@@ -258,9 +258,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [36, 37, 38]
+        python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.1.2"
+          - itk-python-git-tag: "v5.2rc2"
 
     steps:
     - uses: actions/checkout@v2
@@ -292,7 +292,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.2"
+          - itk-python-git-tag: "v5.2rc2"
 
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(_itk_build_testing ${BUILD_TESTING})
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "b14136798b928645cf5415248556fe49ca3e338a")
+set(elastix_GIT_TAG "7677baf31ca9fafbdaa0f928d0e8affb3f5a8295")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(_itk_build_testing ${BUILD_TESTING})
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "e72d2b690d0a0d869ec89cb9bd444a450d21bf88")
+set(elastix_GIT_TAG "b14136798b928645cf5415248556fe49ca3e338a")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.2rc1'
+        r'itk>=5.2rc2'
     ]
     )

--- a/wrapping/dockcross-manylinux-build-module-wheels-opencl.sh
+++ b/wrapping/dockcross-manylinux-build-module-wheels-opencl.sh
@@ -6,10 +6,10 @@
 # Versions can be restricted by passing them in as arguments to the script
 # For example,
 #
-#   scripts/dockcross-manylinux-build-module-wheels.sh cp27mu cp35
+#   scripts/dockcross-manylinux-build-module-wheels.sh cp39
 
 # Generate dockcross scripts
-docker run --rm dockcross/manylinux1-x64:20200416-a6b6635 > /tmp/dockcross-manylinux-x64
+docker run --rm dockcross/manylinux2014-x64:20201015-96d8741 > /tmp/dockcross-manylinux-x64
 chmod u+x /tmp/dockcross-manylinux-x64
 
 script_dir=$(cd $(dirname $0) || exit 1; pwd)
@@ -35,7 +35,7 @@ fi
 
 # Build wheels
 mkdir -p dist
-DOCKER_ARGS="-e ELASTIX_USE_OPENCL=1 -v $(pwd)/dist:/work/dist/ -v $(pwd)/ITKPythonPackage:/ITKPythonPackage -v $(pwd)/tools:/tools -v $(pwd)/OpenCL-ICD-Loader/inc/CL:/usr/include/CL -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so.1 -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so"
+DOCKER_ARGS="-e ELASTIX_USE_OPENCL=1 -v $(pwd)/dist:/work/dist/ -v $script_dir/..:/ITKPythonPackage -v $(pwd)/tools:/tools -v $(pwd)/OpenCL-ICD-Loader/inc/CL:/usr/include/CL -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so.1 -v $(pwd)/OpenCL-ICD-Loader-build/libOpenCL.so.1.2:/usr/lib64/libOpenCL.so"
 /tmp/dockcross-manylinux-x64 \
   -a "$DOCKER_ARGS" \
   "/ITKPythonPackage/scripts/internal/manylinux-build-module-wheels.sh" "$@"


### PR DESCRIPTION
Elastix also needed a flag to support 4D floats, which is set in this PR.
However running a 4D registration now, results in ITK giving a MemoryAllocationError, while there's 100gb free space on my drive for a 4D registration of 4 100x100x100 images. This should be enough right?
Any suggestions for a workaround?
