### PR TITLE
STYLE:Remove unnecessary notebook imports

### DIFF
--- a/examples/ITK_Example01_SimpleRegistration.ipynb
+++ b/examples/ITK_Example01_SimpleRegistration.ipynb
@@ -20,8 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First import is currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
     "import itk\n",
     "from itkwidgets import compare, checkerboard\n",
     "import numpy as np"
@@ -248,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example02_CustomOrMultipleParameterMaps.ipynb
+++ b/examples/ITK_Example02_CustomOrMultipleParameterMaps.ipynb
@@ -20,8 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First two imports are currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
     "import itk"
    ]
   },
@@ -446,7 +444,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example03_Masked_3D_Registration.ipynb
+++ b/examples/ITK_Example03_Masked_3D_Registration.ipynb
@@ -31,8 +31,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First import is currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
     "import itk\n",
     "from itkwidgets import compare, checkerboard, view"
    ]
@@ -264,7 +262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example04_InitialTransformAndMultiThreading.ipynb
+++ b/examples/ITK_Example04_InitialTransformAndMultiThreading.ipynb
@@ -35,8 +35,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First import is currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
     "import itk"
    ]
   },
@@ -136,7 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example05_PointRegistration.ipynb
+++ b/examples/ITK_Example05_PointRegistration.ipynb
@@ -28,8 +28,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First import is currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
     "import itk\n",
     "import numpy as np\n",
     "from itkwidgets import compare, checkerboard, view"
@@ -193,7 +191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example06_GroupwiseRegistration.ipynb
+++ b/examples/ITK_Example06_GroupwiseRegistration.ipynb
@@ -29,9 +29,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First import is currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "import itk\n"
+    "import itk"
    ]
   },
   {
@@ -134,7 +132,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example06_GroupwiseRegistration.ipynb
+++ b/examples/ITK_Example06_GroupwiseRegistration.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Groupwise registration methods try to mitigate uncertainties associated with any one image by simultaneously registering all images in a population. This incorporates all image information in registration process and eliminates bias towards a chosen reference frame. The method described here uses a 3D (2D+time) and 4D (3D+time) free-form B-spline deformation model and a similarity metric that minimizes variance of intensities under the constraint that the average deformation over images is zero. This constraint defines a true mean frame of reference that lie in the center of the population without having to calculate it explicitly.\n",
+    "Groupwise registration methods try to mitigate uncertainties associated with any one image by simultaneously registering all images in a population. This incorporates all image information in registration process and eliminates bias towards a chosen reference frame. The method described here uses a 3D (2D+time) free-form B-spline deformation model and a similarity metric that minimizes variance of intensities under the constraint that the average deformation over images is zero. This constraint defines a true mean frame of reference that lie in the center of the population without having to calculate it explicitly.\n",
     "\n",
     "The method can take into account temporal smoothness of the deformations and a cyclic transform in the time dimension. This may be appropriate if it is known a priori that the anatomical motion has a cyclic nature e.g. in cases of cardiac or respiratory motion."
    ]
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Registration (WIP; to be continued ...)"
+    "### Registration"
    ]
   },
   {
@@ -38,11 +38,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load  images\n",
-    "vector_of_images = []\n",
-    "for i in range(10):\n",
-    "    image = itk.imread('data/00/00-slice00%s.dcm'%i, itk.F)\n",
-    "    vector_of_images.append(image)"
+    "# Load folder containing images.\n",
+    "images = itk.imread(\"data/00\", itk.F)"
    ]
   },
   {
@@ -66,19 +63,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Call registration function\n",
     "# both fixed and moving image should be set with the vector_itk to prevent elastix from throwing errors\n",
-    "####### ----- Error for 3D+time case, itk package not build for 4D images, \n",
-    "####### ----- options to rebuild with different flag possible----- ######\n",
     "\n",
-    "# result_image, result_transform_parameters = itk.elastix_registration_method(\n",
-    "#     vector_of_images, vector_of_images,\n",
-    "#     parameter_object=parameter_object,\n",
-    "#     log_to_console=True)"
+    "result_image, result_transform_parameters = itk.elastix_registration_method(\n",
+    "    images, images,\n",
+    "    parameter_object=parameter_object,\n",
+    "    log_to_console=True)"
    ]
   },
   {
@@ -90,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,20 +94,18 @@
     "# the correct 3D class is initialized.\n",
     "# Both fixed and moving image should be set with the vector_itk to prevent elastix from throwing errors\n",
     "\n",
-    "####### ----- Error for 3D+time case ----- ######\n",
-    "\n",
-    "#elastix_object = itk.ElastixRegistrationMethod.New(vector_of_images, vector_of_images)\n",
-    "#elastix_object.SetParameterObject(parameter_object)\n",
+    "elastix_object = itk.ElastixRegistrationMethod.New(images, images)\n",
+    "elastix_object.SetParameterObject(parameter_object)\n",
     "\n",
     "# Set additional options\n",
-    "#elastix_object.SetLogToConsole(False)\n",
+    "elastix_object.SetLogToConsole(False)\n",
     "\n",
     "# Update filter object (required)\n",
-    "#elastix_object.UpdateLargestPossibleRegion()\n",
+    "elastix_object.UpdateLargestPossibleRegion()\n",
     "\n",
     "# Results of Registration\n",
-    "#result_image = elastix_object.GetOutput()\n",
-    "#result_transform_parameters = elastix_object.GetTransformParameterObject()"
+    "result_image = elastix_object.GetOutput()\n",
+    "result_transform_parameters = elastix_object.GetTransformParameterObject()"
    ]
   }
  ],

--- a/examples/ITK_Example07_MultimetricMultiImageRegistration.ipynb
+++ b/examples/ITK_Example07_MultimetricMultiImageRegistration.ipynb
@@ -20,8 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First import is currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
     "import itk"
    ]
   },
@@ -213,7 +211,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example08_SimpleTransformix.ipynb
+++ b/examples/ITK_Example08_SimpleTransformix.ipynb
@@ -29,9 +29,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First two imports are currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "from itkwidgets import compare, checkerboard"
    ]
@@ -207,7 +204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example09_PointSetAndMaskTransformation.ipynb
+++ b/examples/ITK_Example09_PointSetAndMaskTransformation.ipynb
@@ -31,9 +31,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First two import are currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "from itkwidgets import compare, checkerboard"
@@ -296,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example10_Transformix_Jacobian.ipynb
+++ b/examples/ITK_Example10_Transformix_Jacobian.ipynb
@@ -29,9 +29,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First two import are currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np"
    ]
@@ -199,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example11_Transformix_DeformationField.ipynb
+++ b/examples/ITK_Example11_Transformix_DeformationField.ipynb
@@ -28,9 +28,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First two import are currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk"
    ]
   },
@@ -279,7 +276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_Example12_DifferentSizeTransformation.ipynb
+++ b/examples/ITK_Example12_DifferentSizeTransformation.ipynb
@@ -23,9 +23,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# First two import are currently necessary to run ITKElastix on MacOs\n",
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -173,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_UnitTestExample1_RigidRegistration.ipynb
+++ b/examples/ITK_UnitTestExample1_RigidRegistration.ipynb
@@ -15,8 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -135,7 +133,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_UnitTestExample2_AffineRegistration.ipynb
+++ b/examples/ITK_UnitTestExample2_AffineRegistration.ipynb
@@ -15,8 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -136,7 +134,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_UnitTestExample3_BsplineRegistration.ipynb
+++ b/examples/ITK_UnitTestExample3_BsplineRegistration.ipynb
@@ -15,8 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -174,7 +172,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_UnitTestExample4_MaskedRegistration.ipynb
+++ b/examples/ITK_UnitTestExample4_MaskedRegistration.ipynb
@@ -15,8 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -142,7 +140,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_UnitTestExample5_GroupwiseRegistration.ipynb
+++ b/examples/ITK_UnitTestExample5_GroupwiseRegistration.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,14 +29,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def image_generator(x1, x2, y1, y2):\n",
+    "# Image generator functions\n",
+    "def image_generator_2D(x1, x2, y1, y2):\n",
     "    image = np.zeros([100, 100], np.float32)\n",
     "    image[y1:y2, x1:x2] = 1\n",
-    "    image = itk.image_view_from_array(image)\n",
+    "    return image\n",
+    "\n",
+    "\n",
+    "def image_generator_3D(x1, x2, y1, y2, z1, z2):\n",
+    "    image = np.zeros([10, 10, 10], np.float32)\n",
+    "    image[z1:z2, y1:y2, x1:x2] = 1\n",
     "    return image"
    ]
   },
@@ -44,24 +50,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Groupwise Registration Test"
+    "### Groupwise Registration Test (3D registration, 2D+time)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create a vector of images for a 2D+time example in numpy\n",
-    "vector_of_images = np.zeros([6, 100, 100], np.float32)\n",
+    "array_of_images = np.zeros([6, 100, 100], np.float32)\n",
     "i = 0\n",
     "for x in range(0, 30, 5):\n",
-    "    image = image_generator(x, x+50, x, x+50)\n",
-    "    vector_of_images[i] = image\n",
+    "    image = image_generator_2D(x, x+50, x, x+50)\n",
+    "    array_of_images[i] = image\n",
     "    i += 1\n",
     "\n",
-    "vector_itk = itk.image_view_from_array(vector_of_images)\n",
+    "image_itk = itk.image_view_from_array(array_of_images)\n",
     "\n",
     "# Create Groupwise Parameter Object\n",
     "parameter_object = itk.ParameterObject.New()\n",
@@ -74,9 +80,9 @@
     "parameter_object.AddParameterMap(groupwise_parameter_map)\n",
     "\n",
     "result_image, result_transform_parameters = itk.elastix_registration_method(\n",
-    "    vector_itk, vector_itk,\n",
+    "    image_itk, image_itk,\n",
     "    parameter_object,\n",
-    "    log_to_console=True)"
+    "    log_to_console=False)"
    ]
   },
   {
@@ -89,7 +95,9 @@
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -124,6 +132,45 @@
     "axs[1,2].imshow(result_image_np[5])\n",
     "axs[1,2].set_title('Result', fontsize=30)\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Groupwise Registration Test (4D registration, 3D+time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a vector of images for a 3D+time example in numpy\n",
+    "array_of_images = np.zeros([6, 10, 10, 10], np.float32)\n",
+    "i = 0\n",
+    "for x in range(0, 30, 5):\n",
+    "    image = image_generator_3D(x, x+50, x, x+50, x, x+50)\n",
+    "    array_of_images[i] = image\n",
+    "    i += 1\n",
+    "\n",
+    "image_itk = itk.image_view_from_array(array_of_images)\n",
+    "\n",
+    "# Create Groupwise Parameter Object\n",
+    "parameter_object = itk.ParameterObject.New()\n",
+    "groupwise_parameter_map = parameter_object.GetDefaultParameterMap('groupwise',4)\n",
+    "groupwise_parameter_map['FinalBSplineInterpolationOrder'] = ['0']\n",
+    "groupwise_parameter_map['Transform'] = ['EulerStackTransform']\n",
+    "groupwise_parameter_map['AutomaticScalesEstimation'] = ['true']\n",
+    "groupwise_parameter_map['AutomaticScalesEstimationStackTransform'] = ['true']\n",
+    "\n",
+    "parameter_object.AddParameterMap(groupwise_parameter_map)\n",
+    "\n",
+    "result_image, result_transform_parameters = itk.elastix_registration_method(\n",
+    "    image_itk, image_itk,\n",
+    "    parameter_object,\n",
+    "    log_to_console=False)"
    ]
   }
  ],

--- a/examples/ITK_UnitTestExample5_GroupwiseRegistration.ipynb
+++ b/examples/ITK_UnitTestExample5_GroupwiseRegistration.ipynb
@@ -15,8 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -145,7 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_UnitTestExample6_PointSetTransformation.ipynb
+++ b/examples/ITK_UnitTestExample6_PointSetTransformation.ipynb
@@ -15,8 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -176,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,

--- a/examples/ITK_UnitTestExample7_SizeTransformation.ipynb
+++ b/examples/ITK_UnitTestExample7_SizeTransformation.ipynb
@@ -15,8 +15,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from itk import itkElastixRegistrationMethodPython\n",
-    "from itk import itkTransformixFilterPython\n",
     "import itk\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
@@ -175,7 +173,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR should only be merged after #102 is merged.
After that merge the notebook import statements are not necessary anymore on MacOS.
At least not for the itk-elastix functionality currently tested by the notebooks.
