### PR TITLE
DOC:Update composite transform order

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.2rc02"
+            itk-git-tag: "c7586a12e8538c59041c480880ff0ea15c9550c2"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.2rc02"
+            itk-git-tag: "c7586a12e8538c59041c480880ff0ea15c9550c2"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.2rc02"
+            itk-git-tag: "c7586a12e8538c59041c480880ff0ea15c9550c2"
             cmake-build-type: "MinSizeRel"
 
     steps:

--- a/examples/ITK_Example13_ITKResampling.ipynb
+++ b/examples/ITK_Example13_ITKResampling.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,15 +119,17 @@
     "    itk_parameters[i] = p\n",
     "affine_transform.SetParameters(itk_parameters)\n",
     "\n",
-    "\n",
+    "# When creating the composite transform for itk, \n",
+    "# take into account that elastix uses T2(T1(x)) while itk does this the other way around.\n",
+    "# So to get the correct composite transform, add the last transform in elastix first in itk.\n",
     "composite_transform = itk.CompositeTransform[itk.D, dimension].New()\n",
-    "composite_transform.AddTransform(euler_transform)\n",
-    "composite_transform.AddTransform(affine_transform)"
+    "composite_transform.AddTransform(affine_transform)\n",
+    "composite_transform.AddTransform(euler_transform)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,26 +143,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    ".. or by initiating an transformix image filter object similar to the elastix algorithm."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Visualization\n",
     "The results of the image transform can be visualized with widgets from the itkwidget library such as the checkerboard and compare widgets."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "98cb0d2c2550468eb7d1270f63c28251",
+       "model_id": "3df906dd6b44476690d74150fdfb0429",
        "version_major": 2,
        "version_minor": 0
       },
@@ -178,13 +173,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8df5458d1cdd4ea89b9818ca71fc24a7",
+       "model_id": "2e7cfc110f904511939f9314fae2d40b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -203,9 +198,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "ElastixEnv",
    "language": "python",
-   "name": "python3"
+   "name": "elastixenv"
   },
   "language_info": {
    "codemirror_mode": {
@@ -217,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updates example notebook that shows the difference in composite transform order between elastix and itk discussed in #110 