### PR TITLE
ENH: Bump ITK to v5.3rc04.post2

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -108,10 +108,21 @@ jobs:
         if(WIN32)
           set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
         endif()
-        set(dashboard_cache "
-        ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
-        BUILD_TESTING:BOOL=ON
-        ")
+        if(APPLE)
+          # Switch off OpenMP, to work around macOS specific CI errors, saying:
+          # > fatal error: ‘omp.h’ file not found
+          # See https://github.com/SuperElastix/elastix/commit/72c8590cd563e3f72a2dfbbc69ad2d05a6a3b936
+          set(dashboard_cache "
+          ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
+          BUILD_TESTING:BOOL=ON
+          ELASTIX_USE_OPENMP:BOOL=OFF
+          ")
+        else()
+          set(dashboard_cache "
+          ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
+          BUILD_TESTING:BOOL=ON
+          ")
+        endif()
         string(TIMESTAMP build_date "%Y-%m-%d")
         message("CDash Build Identifier: \${build_date} \${CTEST_BUILD_NAME}")
         message("CTEST_SITE = \${CTEST_SITE}")
@@ -190,7 +201,8 @@ jobs:
       run: |
         export ITK_PACKAGE_VERSION=${{ env.itk-wheel-tag }}
         export MACOSX_DEPLOYMENT_TARGET=10.9
-        ./macpython-download-cache-and-build-module-wheels.sh
+        # See https://github.com/SuperElastix/elastix/commit/72c8590cd563e3f72a2dfbbc69ad2d05a6a3b936 for OpenMP workaround
+        ./macpython-download-cache-and-build-module-wheels.sh --cmake_options "-DELASTIX_USE_OPENMP:BOOL=OFF"
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,8 +3,8 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "6046668162b56a2836abf733c0626e61516b29cd"
-  itk-wheel-tag: "v5.3rc04"
+  itk-git-tag: "835dc01388d22c4b4c9a46b01dbdfe394ec23511"
+  itk-wheel-tag: "v5.3rc04.post2"
 
 jobs:
   build-test-cxx:

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you use this software anywhere we would appreciate if you cite the following 
     for Diagnostic Classification of Alzheimer's Disease\", Frontiers in
     Neuroinformatics, vol. 7, no. 50, pp. 1-15, January 2014.
 
-This ITK module is based on [SimpleElastix](http://simpleelastix.github.io/), created by [Kasper Marstal](https://github.com/kaspermarstal). For more information, see:
+This ITK module is based on [SimpleElastix](https://simpleelastix.github.io/), created by [Kasper Marstal](https://github.com/kaspermarstal). For more information, see:
 
 -   Kasper Marstal, Floris Berendsen, Marius Staring and Stefan Klein,
     \"SimpleElastix: A user-friendly, multi-lingual library for medical

--- a/examples/ITK_Example02_CustomOrMultipleParameterMaps.ipynb
+++ b/examples/ITK_Example02_CustomOrMultipleParameterMaps.ipynb
@@ -48,7 +48,7 @@
     "- *spline*\n",
     "- *groupwise*\n",
     "\n",
-    "transformations. More information on these transformation and on all possible parameter settings can be found in the [elastix manual](http://elastix.isi.uu.nl/download/elastix-5.0.0-manual.pdf)."
+    "transformations. More information on these transformation and on all possible parameter settings can be found in the [elastix manual](https://elastix.lumc.nl/download/elastix-5.0.1-manual.pdf)."
    ]
   },
   {

--- a/examples/ITK_Example03_Masked_3D_Registration.ipynb.needtofix
+++ b/examples/ITK_Example03_Masked_3D_Registration.ipynb.needtofix
@@ -22,7 +22,7 @@
     "\n",
     "A mask is a binary image with 1 meaning that a pixel is include in elastix' computation and a 0 meaning it's not.\n",
     "\n",
-    "For more information, see Section 5.4, \"Masks\" of the [Elastix Manual](http://elastix.isi.uu.nl/download/elastix-5.0.0-manual.pdf)."
+    "For more information, see Section 5.4, \"Masks\" of the [Elastix Manual](https://elastix.lumc.nl/download/elastix-5.0.1-manual.pdf)."
    ]
   },
   {

--- a/examples/ITK_Example08_SimpleTransformix.ipynb
+++ b/examples/ITK_Example08_SimpleTransformix.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "After image registrations it is often useful to apply the transformation as found by the registration to another image. Maybe you want to apply the transformation to an original (larger) image to gain resolution. Or maybe you need the transformation to apply it to a label image (segmentation). Transformix is an image filter that was developed together with elastix, that can be used to do these transformations.\n",
     "\n",
-    "A spatial transformation is defined as a mapping from the fixed image domain to the moving image domain. More information on the precise definition of the transform can be found in the [elastix manual](http://elastix.isi.uu.nl/download/elastix-5.0.0-manual.pdf). Transformix can be used to apply this mapping not only to images, but also to masks (binary images) and point sets see [example 9](ITK_Example09_PointSetAndMaskTransformation.ipynb#section_id10).\n",
+    "A spatial transformation is defined as a mapping from the fixed image domain to the moving image domain. More information on the precise definition of the transform can be found in the [elastix manual](https://elastix.lumc.nl/download/elastix-5.0.1-manual.pdf). Transformix can be used to apply this mapping not only to images, but also to masks (binary images) and point sets see [example 9](ITK_Example09_PointSetAndMaskTransformation.ipynb#section_id10).\n",
     "\n",
     "As an alternative, see the [itk resampling example](ITK_Example13_ITKResampling.ipynb)."
    ]

--- a/examples/ITK_Example10_Transformix_Jacobian.ipynb
+++ b/examples/ITK_Example10_Transformix_Jacobian.ipynb
@@ -159,7 +159,7 @@
     "preservation. The measure is quantitative: a value of 1.1 means a 10% increase in volume. If this\n",
     "value deviates substantially from 1, you may be worried (but maybe not if this is what you expect for\n",
     "your application). In case it is negative you have “foldings” in your transformation, and you definitely\n",
-    "should be worried. For more information see [elastix manual](http://elastix.isi.uu.nl/download/elastix-5.0.0-manual.pdf)."
+    "should be worried. For more information see [elastix manual](https://elastix.lumc.nl/download/elastix-5.0.1-manual.pdf)."
    ]
   },
   {

--- a/examples/ITK_Example13_ITKResampling.ipynb
+++ b/examples/ITK_Example13_ITKResampling.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "After image registrations it is often useful to apply the transformation as found by the registration to another image. Maybe you want to apply the transformation to an original (larger) image to gain resolution. Or maybe you need the transformation to apply it to a label image (segmentation). The `itk.resample_image_filter` function will resample an image given a sampling grid, a spatial transformation, and an interpolation function.\n",
     "\n",
-    "A spatial transformation is defined as a mapping from the fixed image domain to the moving image domain. More information on the precise definition of the transform can be found in the [Elastix Manual](http://elastix.isi.uu.nl/download/elastix-5.0.0-manual.pdf) or the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf).\n",
+    "A spatial transformation is defined as a mapping from the fixed image domain to the moving image domain. More information on the precise definition of the transform can be found in the [Elastix Manual](https://elastix.lumc.nl/download/elastix-5.0.1-manual.pdf) or the [ITK Software Guide](https://itk.org/ItkSoftwareGuide.pdf).\n",
     "\n",
     "As an alternative, see the [transformix example](ITK_Example08_SimpleTransformix.ipynb)."
    ]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if 'ELASTIX_USE_OPENCL' in os.environ:
 
 setup(
     name=package_name,
-    version='0.14.1',
+    version='0.14.2',
     author='Insight Software Consortium',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],
@@ -49,6 +49,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.3rc4'
+        r'itk>=5.3rc4.post2'
     ]
     )

--- a/test/itkElastixRegistrationMethodTest.cxx
+++ b/test/itkElastixRegistrationMethodTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/wrapping/test/itkElastixRegistrationMethodTest.py
+++ b/wrapping/test/itkElastixRegistrationMethodTest.py
@@ -6,7 +6,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,

--- a/wrapping/test/itkTransformixFilterTest.py
+++ b/wrapping/test/itkTransformixFilterTest.py
@@ -6,7 +6,7 @@
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
 #
-#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#          https://www.apache.org/licenses/LICENSE-2.0.txt
 #
 #   Unless required by applicable law or agreed to in writing, software
 #   distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
- Bumps ITK dependency to `v5.3rc04.post2` tag
- Disables building Elastix with OpenMP on MacOS: xref [https://github.com/SuperElastix/elastix/issues/650](https://github.com/SuperElastix/elastix/issues/650)
- KWStyle and broken hyperlink fixes

New ITKElastix 0.14.2 packages are anticipated to address [https://github.com/InsightSoftwareConsortium/ITKElastix/issues/159](https://github.com/InsightSoftwareConsortium/ITKElastix/issues/159).