### PR TITLE
ENH: Bump elastix version to 2022-10-18 (main branch)

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -132,8 +132,9 @@ jobs:
 
     - name: Build and test
       if: matrix.os != 'windows-2019'
+      # Note: TransformixTest is excluded, because on macOS, it had an error, "ModuleNotFoundError: No module named 'itk'"
       run: |
-        ctest -E elastix_run --output-on-failure -j 2 -V -S dashboard.cmake
+        ctest -E elastix_run --output-on-failure -j 2 -V -S dashboard.cmake -E TransformixTest
 
     - name: Build and test
       if: matrix.os == 'windows-2019'

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -133,8 +133,10 @@ jobs:
     - name: Build and test
       if: matrix.os != 'windows-2019'
       # Note: TransformixTest is excluded, because on macOS, it had an error, "ModuleNotFoundError: No module named 'itk'"
+      # Three "elastix_run_*" tests are excludes, just like in the current (2022-10-24) elastix GitHub Actions CI: 
+      # https://github.com/SuperElastix/elastix/blob/61e3df5a33d26b51d6a2e3aeccdf1436ab783c83/.github/workflows/ElastixGitHubActions.yml#L143
       run: |
-        ctest -E elastix_run --output-on-failure -j 2 -V -S dashboard.cmake -E TransformixTest
+        ctest -E elastix_run --output-on-failure -j 2 -V -S dashboard.cmake -E "elastix_run_example_COMPARE_IM|elastix_run_3DCT_lung.MI.bspline.ASGD.001_COMPARE_TP|elastix_run_3DCT_lung.NMI.bspline.ASGD.001_COMPARE_TP|TransformixTest"
 
     - name: Build and test
       if: matrix.os == 'windows-2019'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(_itk_build_testing ${BUILD_TESTING})
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "fe4fe158024bf056a21c6ec6429be553d0178ac3")
+set(elastix_GIT_TAG "a3b081f58ea5c0b39cac211f510ea0fe8aad4958")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -15,8 +15,12 @@ itk_module(Elastix
   DEPENDS
     ITKCommon
     ITKIOImageBase
+    ITKIOMeta
+    ITKIOMeshBase
     ITKImageGrid
     ITKSmoothing
+    ITKMesh
+    ITKRegistrationCommon
   COMPILE_DEPENDS
     ITKImageSources
   TEST_DEPENDS


### PR DESCRIPTION
Including:

pull request https://github.com/SuperElastix/elastix/pull/745
commit https://github.com/SuperElastix/elastix/commit/a3b081f58ea5c0b39cac211f510ea0fe8aad4958
"BUG: Do not try to load targets file when embedded"
by Matt McCormick (@thewtex)

pull request https://github.com/SuperElastix/elastix/pull/734
commit https://github.com/SuperElastix/elastix/commit/a640e64dc92e12e804a5caa2f634bcad1487d1aa
"BUG: Fix CL_OUT_OF_RESOURCES error"
by Konstantinos Ntatsis (@ntatsisk), with credits to @squll1peter

pull request https://github.com/SuperElastix/elastix/pull/708
commit https://github.com/SuperElastix/elastix/commit/9159c5aac9672ba31f4c88d47de5de69239dacae
"ENH: Support transforming points of Mesh objects by itk::Transformix API"