### PR TITLE
STYLE: Rename CMake ITKElastix project "Elastix" to "ITKElastix"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16.3)
-project(Elastix)
+project(ITKElastix)
 
 # To ease enablement with Python packaging
 if(DEFINED ENV{ELASTIX_USE_OPENCL})
@@ -96,7 +96,6 @@ endif()
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
-  include(ITKModuleExternal)
 else()
   set(ITK_DIR ${CMAKE_BINARY_DIR})
   itk_module_impl()


### PR DESCRIPTION
Aims to avoid confusion between the elastix project and the ITKElastix project.

No longer `include(ITKModuleExternal)`