### PR TITLE
ENH: Bump elastix version to 2022-10-29

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(_itk_build_testing ${BUILD_TESTING})
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "89e8c5487a1fbfc6cbbf5c3a12d47af91ffd1b12")
+set(elastix_GIT_TAG "9e6efb6f9aa3b3545c7365a4b2c97aa2f88a17b5")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}


### PR DESCRIPTION
Including pull request https://github.com/SuperElastix/elastix/pull/750 commit https://github.com/SuperElastix/elastix/commit/9e6efb6f9aa3b3545c7365a4b2c97aa2f88a17b5
"COMP: Use `itkSetConstObjectMacro` for TransformixFilter InputMesh"