### PR TITLE
ENH: Bump elastix version to 2022-12-07

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF) # Elastix does not support shared libs
 
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "9e6efb6f9aa3b3545c7365a4b2c97aa2f88a17b5")
+set(elastix_GIT_TAG "6d90b8d0c5b5ccab8e3dde5107454829b47e2f4d")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}


### PR DESCRIPTION
Including:

pull request https://github.com/SuperElastix/elastix/pull/770
commit https://github.com/SuperElastix/elastix/commit/c0262ba1c713c0a462ada841573e3c452508da3b
"ENH: Add CMake options to not install artifacts", by Matt McCormick (@thewtex)

pull request https://github.com/SuperElastix/elastix/pull/767
"ElastixRegistrationMethod transform objects", adding:

 - ElastixRegistrationMethod::GetCombinationTransform()
 - TransformixFilter::SetCombinationTransform(transform)
 - ElastixRegistrationMethod::GetNumberOfTransforms()
 - ElastixRegistrationMethod::GetNthTransform(n)
 - ElastixRegistrationMethod::ConvertToItkTransform(transform)

pull request https://github.com/SuperElastix/elastix/pull/755
commit https://github.com/SuperElastix/elastix/commit/7fe8ed9b1131e79da7b441827dce0d4abaf64544
"ENH: Add TransformixFilter SpatialJacobian, DeterminantOfSpatialJacobian"
