### PR TITLE
COMP: Remove numpy version pin

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -4,7 +4,7 @@ jupyterlab>=2.2.0
 imageio
 ipywidgets>=7.5.1
 ipympl>=0.5.7
-numpy==1.21.0
+numpy
 torch>=1.9
 monai>=1.0.1
 matplotlib==3.3.1


### PR DESCRIPTION
I believe this was required due to bug's in numpy's typing support that have been fixed in recent versions.