### PR TITLE
DOC: Remove visualization section from ITK_Example01_SimpleRegistration

### DIFF
--- a/examples/ITK_Example01_SimpleRegistration.ipynb
+++ b/examples/ITK_Example01_SimpleRegistration.ipynb
@@ -138,101 +138,11 @@
    "source": [
     "The output of the elastix algorithm is the registered (transformed) version of the moving image. The parameters of this transformation can also be obtained after registation."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Visualization\n",
-    "The results of the image registration can be visualized with widgets from the itkwidget library such as the checkerboard and compare widgets."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2fde35c841cf46b7ac56d0d9bf47a2f6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(Viewer(annotations=False, interpolation=False, rendered_image=<itk.itkImagePython.itkImageF2; p…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "checkerboard(fixed_image, result_image)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5838a4be58a04488aa0121a5f56f987e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "AppLayout(children=(HBox(children=(Label(value='Link:'), Checkbox(value=True, description='cmap'), Checkbox(va…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "compare(fixed_image, result_image, link_cmap=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# import napari"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Cast result images to numpy arrays for Napari Viewer\n",
-    "# fixed_image_np = np.asarray(fixed_image).astype(np.float32)\n",
-    "# moving_image_np = np.asarray(moving_image).astype(np.float32)\n",
-    "# result_image_np = np.asarray(result_image).astype(np.float32)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# with napari.gui_qt():\n",
-    "#     viewer = napari.Viewer()\n",
-    "#     viewer.add_image(fixed_image_np)\n",
-    "#     viewer.add_image(moving_image_np)\n",
-    "#     viewer.add_image(result_image_np)\n"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -246,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
itkwidgets visualization is not currently working in MyBinder. The napari visualization does not work in MyBinder and should be updated to use the itk napari Python package to preserve spatial metadata and also point to the elastix_napari plugin. Updates for these will be tracked in separate issues.