### PR TITLE
Bump elastix version to 2023-05-15, use C++17, support any scalar pixel type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.16.3)
 project(Elastix)
 
+if(NOT CMAKE_CXX_STANDARD)
+  # SuperElastix/elastix uses C++17 specific features in some of its header files.
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 # To ease enablement with Python packaging
 if(DEFINED ENV{ELASTIX_USE_OPENCL})
   set(ELASTIX_USE_OPENCL ON CACHE BOOL "Enable OpenCL support in Elastix")
@@ -51,7 +56,7 @@ if(SKBUILD)
 endif()
 
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "d652938573e5f193955908eba225a854b31ce36a")
+set(elastix_GIT_TAG "b9b8e20aef83f94ed38a81cc38625a1bfddf1053")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}

--- a/wrapping/itkElastixRegistrationMethod.wrap
+++ b/wrapping/itkElastixRegistrationMethod.wrap
@@ -1,4 +1,4 @@
 itk_wrap_class("itk::ElastixRegistrationMethod" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_REAL}" 2)
+  itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 2)
 itk_end_wrap_class()
 

--- a/wrapping/itkTransformixFilter.wrap
+++ b/wrapping/itkTransformixFilter.wrap
@@ -1,4 +1,4 @@
 itk_wrap_class("itk::TransformixFilter" POINTER)
-  itk_wrap_image_filter("${WRAP_ITK_REAL}" 1)
+  itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 1)
 itk_end_wrap_class()
 


### PR DESCRIPTION
Bump elastix version to 2023-05-15, including:

  pull request https://github.com/SuperElastix/elastix/pull/891
  commit https://github.com/SuperElastix/elastix/commit/ed15547044800c835319ac87ebc8b1e6edc0b97e
  "PERF: Fill `jsj` (JacobianOfSpatialJacobian) in-place and remove `jsj1`"

  pull request https://github.com/SuperElastix/elastix/pull/890
  commit https://github.com/SuperElastix/elastix/commit/b9ea3a8e65a3e015a5a0f06acfb5bd22fad8dacc
  "PERF: Fill `jsh` (JacobianOfSpatialJacobian) in-place and remove `jsh1`"
 
  pull request https://github.com/SuperElastix/elastix/pull/887
  commit https://github.com/SuperElastix/elastix/commit/82984859f1e6e1f9a3d53940c3b540e83c263856
  PERF: Make EvaluateParzenValues calls faster, using raw buffer of values

  pull request https://github.com/SuperElastix/elastix/pull/882
  commit https://github.com/SuperElastix/elastix/commit/58e0a7bdd76f69a8615cb4a8856038c0892ea530
  "ENH: Convert the input images to the user-specified internal pixel type"

  pull request https://github.com/SuperElastix/elastix/pull/864
  commit https://github.com/SuperElastix/elastix/commit/c3d478e8e3b6b1806862abbd0d777beff9b66346
  "ENH: Upgrade elastix from C++14 to C++17"

  pull request https://github.com/SuperElastix/elastix/pull/856
  commit https://github.com/SuperElastix/elastix/commit/48c64583c8514eac7fa9ad46848be9d100ac80c9
  "ENH: Add SetInitialTransformParameterObject to ElastixRegistrationMethod"

  pull request https://github.com/SuperElastix/elastix/pull/832
  commit https://github.com/SuperElastix/elastix/commit/05d2b40f23d5b1c1438521e505e349bb54fdf7e4
  ENH: Support "ShowProgressPercentage" parameter (`false` by default)

  pull request https://github.com/SuperElastix/elastix/pull/815
  commit https://github.com/SuperElastix/elastix/commit/c4ef707bb9433e687d45a06408393413f2abe64a
  "ENH: Add `ElastixLogLevel` to the ITK interface"

Explicitly specified C++17 as standard for the compilation of ITKElastix.

Supported any scalar type (not just real) as input pixel type.

Because of the included elastix `PERF` commits, this pull request appears to make the [itkElastixRegistrationMethodTest](https://github.com/InsightSoftwareConsortium/ITKElastix/blob/a7150930fb27f0d2c56bbb466db12431eb180850/test/itkElastixRegistrationMethodTest.cxx) around 10% faster. 