### PR TITLE
COMP: Disable aarch64 Python wheel builds in CI

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -8,5 +8,7 @@ jobs:
 
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@03626a23c22246e89e36c7e918a158c440f9b099
+    with:
+      manylinux-platforms: '["_2_28-x64","2014-x64"]'
     secrets:
       pypi_password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Disables building for aarch64 platform in GitHub Actions. aarch64 wheel builds with emulation were taking around 7x longer than x64 wheels to build and sometimes timing out due to surpassing 6 hours total on GitHub Actions runners.

Consider re-adding support aarch64 support in the future once an immediate need is present and/or tools are improved.

Default platforms were `["_2_28-x64","2014-x64","_2_28-aarch64"]`. The input list is provided so that "_2_28-aarch64" is removed.

Motivated by discussion in #213 