### PR TITLE
BUG: Fix masked registration notebook

### DIFF
--- a/examples/ITK_Example03_Masked_3D_Registration.ipynb
+++ b/examples/ITK_Example03_Masked_3D_Registration.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,6 +55,10 @@
     "# Import Custom Parameter Map\n",
     "parameter_object = itk.ParameterObject.New()\n",
     "parameter_object.AddParameterFile('data/parameters.3D.NC.affine.ASGD.001.txt')\n",
+    "\n",
+    "# \"WriteResultImage\" needs to be set to \"true\" so that the image is resampled at the end of the registration\n",
+    "# and the result_image is populated properly\n",
+    "parameter_object.SetParameter(0, \"WriteResultImage\", \"true\")\n",
     "\n",
     "# Import Mask Images\n",
     "fixed_mask = itk.imread('data/CT_3D_lung_fixed_mask.mha', itk.UC)\n",
@@ -89,7 +93,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e77f22d8efb043b2afc8933a519a20cd",
+       "model_id": "9e0ed89550c043a29bef90625e1cb58e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -113,7 +117,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a25e8065b1af425ea0f055ef6f327dfc",
+       "model_id": "3e093036b3be428389dcebe081bb587b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -145,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,13 +203,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fb1b24b4266543f6a1acc897adfc0f85",
+       "model_id": "94d279f136cc48b3983cc60458776d58",
        "version_major": 2,
        "version_minor": 0
       },
@@ -223,13 +227,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bbad23662da64e76a9d94c57fc252c28",
+       "model_id": "b68308d4d978479789642fe885a49896",
        "version_major": 2,
        "version_minor": 0
       },
@@ -244,11 +248,18 @@
    "source": [
     "compare(fixed_image, result_image, label_image= [fixed_image, result_image],link_cmap=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -262,7 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes https://github.com/InsightSoftwareConsortium/ITKElastix/issues/127. `"WriteResultImage"` needs to be set to `"true"` otherwise no result image is produced (this leads to an error stating the itk buffer is empty).

Please take a look at this comment for the use of masks: https://github.com/InsightSoftwareConsortium/ITKElastix/issues/127#issuecomment-1542191151

