### PR TITLE
BUG: Run full Python packaging CI on GitHub Actions tag event

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -16,7 +16,7 @@ jobs:
       pypi_password: ${{ secrets.pypi_password }}
       
   python-build-workflow-main:
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@85252b549b1e44aa7198fbea470f75732d092c8b
     with:
       python3-minor-versions: '["7","8","9","10","11"]'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if 'ELASTIX_USE_OPENCL' in os.environ:
 
 setup(
     name=package_name,
-    version='0.17.0',
+    version='0.17.1',
     author='Insight Software Consortium',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],


### PR DESCRIPTION
Resolves issue where wrong Python CI pipeline ran on v0.17.0 tag action due to missing tag event handling.

https://github.com/InsightSoftwareConsortium/ITKElastix/actions/runs/4998680253

Resolution is based on GitHub Actions contexts documentation. Tested with a similar approach in my tbirdso/ITKSplitComponents fork.

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context