### PR TITLE
BUG: Avoid running development CI on tagged versions

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -7,7 +7,7 @@ jobs:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@85252b549b1e44aa7198fbea470f75732d092c8b
 
   python-build-workflow-dev:
-    if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main'
+    if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags')
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@85252b549b1e44aa7198fbea470f75732d092c8b
     with:
       python3-minor-versions: '["7","11"]'


### PR DESCRIPTION
Followup to 600fcce2 disabling `python-build-workflow-dev` from running on version tag. `python-build-workflow-main` is responsible for executing full Python packaging coveraging on tags, the developer branch simply duplicates a subset of packages.

Based on duplicate pipelines running for 0.17.1:

https://github.com/InsightSoftwareConsortium/ITKElastix/actions/runs/5004635327

I do not anticipate that we will need to tag another version for these changes, but will keep an eye on the 0.17.1 CI pipelines to verify.