### PR TITLE
ENH: Update required versions itk-elastix, torch, and monai in ".binder"

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,12 +1,12 @@
-itk-elastix>=0.17.1
+itk-elastix>=0.17.3
 itkwidgets>=0.32.0
 jupyterlab>=2.2.0
 imageio
 ipywidgets>=7.5.1
 ipympl>=0.5.7
 numpy
-torch>=1.9
-monai>=1.0.1
+torch>=2.0
+monai>=1.2.0
 matplotlib==3.3.1
 PyQt5==5.15.0
 PyQt5-sip==12.8.0


### PR DESCRIPTION
Updated the requirements for the Jupyter notebooks in ITKElastix/examples/

Suggested by Konstantinos Ntatsis (@ntatsisk).