### PR TITLE
ENH: Update elastix version to 2023-08-16, inc. ExternalInitialTransform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(SKBUILD)
 endif()
 
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "115d8e1c7b0b23973bfc919a2bf4768f32e4e843")
+set(elastix_GIT_TAG "23937288318b4ff42b225fbbfbc4abb128e06384")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}


### PR DESCRIPTION
Including pull request https://github.com/SuperElastix/elastix/pull/944

Adds a `SetExternalInitialTransform` member function to `ElastixRegistrationMethod`, allowing to specify any ITK transform as initial transform.