### PR TITLE
v0.18.1: Upgrade elastix to 2023-09-18, converts external initial transforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(SKBUILD)
 endif()
 
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-set(elastix_GIT_TAG "23937288318b4ff42b225fbbfbc4abb128e06384")
+set(elastix_GIT_TAG "798ecaebab9d264d0f3cb375a1bf74174c41343c")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ if 'ELASTIX_USE_OPENCL' in os.environ:
 
 setup(
     name=package_name,
-    version='0.18.0',
+    version='0.18.1',
     author='Insight Software Consortium',
     author_email='itk+community@discourse.itk.org',
     packages=['itk'],


### PR DESCRIPTION
Supports passing a transform retrieved by `GetCombinationTransform()` or `GetNthTransform(n)` to `ConvertToItkTransform`, when an _external_ initial transform was specified before running the registration.

Also including various performance improvements.

Including:

  pull request https://github.com/SuperElastix/elastix/pull/946
  commit https://github.com/SuperElastix/elastix/commit/7bcb2b3ec7b59c85ac9f1cf1564cc90285eabb25
  ENH: Write external initial transforms to ITK transform file

  pull request https://github.com/SuperElastix/elastix/pull/949
  commit https://github.com/SuperElastix/elastix/commit/601f4656e912cc1388fbfa4509d531b7ea5c302f
  ENH: `ConvertToItkTransform` should support external initial transform

  pull request https://github.com/SuperElastix/elastix/pull/950
  commit https://github.com/SuperElastix/elastix/commit/7e883bf473e65761db9a185bb943873962e26eaa
  ENH: Add GetInitialTransform() and GetExternalInitialTransform()

  pull request https://github.com/SuperElastix/elastix/pull/959
  commit https://github.com/SuperElastix/elastix/commit/3979978aaf712c3c78cacdf64eb451aff6eb553d
  PERF: Speed up ComputeJacobianTerms access to `vnl_sparse_matrix`

  pull request https://github.com/SuperElastix/elastix/pull/960
  commit https://github.com/SuperElastix/elastix/commit/4d028f73990347066f8223c2f594e8ae9ae333bb
  PERF: Speed up full, grid, sparse mask samplers by a local sampleVector