### PR TITLE
ENH: Require at least ITK 5.4rc2, for ImageRandomIteratorWithIndex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.4rc1'
+        r'itk>=5.4rc2'
     ]
     )


### PR DESCRIPTION
Especially to avoid potential differences between registration results of the elastix executable and ITKElastix, which were accidentally introduced with ITK 5.4rc1 and fixed with ITK 5.4rc2:

  pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4183
  commit https://github.com/InsightSoftwareConsortium/ITK/commit/997ff54d59335b3dc55ff54e8175c9050a84a3c3
  BUG: ImageRandomIteratorWithIndex should not assign data in constructor