### PR TITLE
BUG: Remove timeout-minutes entry from build-test-package.yml

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -11,7 +11,6 @@ on:
       - main
 
 jobs:
-  timeout-minutes: 360
   cxx-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
 


### PR DESCRIPTION
360 is already the default.

This is marked as invalid by GitHub:

  https://github.com/InsightSoftwareConsortium/ITKElastix/actions/runs/10372464472/workflow