### PR TITLE
BUG: Update CI Cypress dependency installation for Ubuntu 24.04

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Install cypress deps
       run: |
         sudo apt-get update
-        # https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies
-        sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+        # https://docs.cypress.io/app/get-started/install-cypress#UbuntuDebian
+        sudo apt-get install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
 
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 


### PR DESCRIPTION
Source:

  https://docs.cypress.io/app/get-started/install-cypress#UbuntuDebian

@N-Dekker getting there 🔢 
