### PR TITLE
COMP: Drop Python 3.8 (end of life)

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags')
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
     with:
-      python3-minor-versions: '["8","11"]'
+      python3-minor-versions: '["9","11"]'
       manylinux-platforms: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
       test-notebooks: true
     secrets:
@@ -28,7 +28,7 @@ jobs:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
     with:
-      python3-minor-versions: '["8","9","10","11"]'
+      python3-minor-versions: '["9","10","11"]'
       manylinux-platforms: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
       test-notebooks: true
     secrets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itk~=5.4.0",
 ]


### PR DESCRIPTION
Python 3.8 is officially unsupported from 2024-10-07. Python 3.9 should remain supported until October, according to https://devguide.python.org/versions/