### PR TITLE
Remove Python 3.8 from wasm/python pyproject.toml files

### DIFF
--- a/wasm/python/itkwasm-elastix-emscripten/pyproject.toml
+++ b/wasm/python/itkwasm-elastix-emscripten/pyproject.toml
@@ -29,7 +29,7 @@ keywords = [
   "emscripten",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itkwasm >= 1.0.b178",
 ]

--- a/wasm/python/itkwasm-elastix-emscripten/pyproject.toml
+++ b/wasm/python/itkwasm-elastix-emscripten/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/wasm/python/itkwasm-elastix-wasi/pyproject.toml
+++ b/wasm/python/itkwasm-elastix-wasi/pyproject.toml
@@ -29,7 +29,7 @@ keywords = [
   "wasi",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itkwasm >= 1.0.b177",
     "importlib_resources",

--- a/wasm/python/itkwasm-elastix-wasi/pyproject.toml
+++ b/wasm/python/itkwasm-elastix-wasi/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/wasm/python/itkwasm-elastix/pyproject.toml
+++ b/wasm/python/itkwasm-elastix/pyproject.toml
@@ -30,7 +30,7 @@ keywords = [
   "emscripten",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itkwasm >= 1.0.b178",
     "itkwasm-elastix-wasi; sys_platform != \"emscripten\"",

--- a/wasm/python/itkwasm-elastix/pyproject.toml
+++ b/wasm/python/itkwasm-elastix/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
- Follow-up to https://github.com/InsightSoftwareConsortium/ITKElastix/pull/319 commit 2d237429e75b83644d6937c3c318e9a9e7bdd193
"COMP: Drop Python 3.8 (end of life)"