### PR TITLE
ENH: Add Python 3.12 and 3.13 to build-test-package CI workflow

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags')
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.2
     with:
-      python3-minor-versions: '["9","11"]'
+      python3-minor-versions: '["9","13"]'
       manylinux-platforms: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
       test-notebooks: true
     secrets:
@@ -28,7 +28,7 @@ jobs:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.2
     with:
-      python3-minor-versions: '["9","10","11"]'
+      python3-minor-versions: '["9","10","11","12","13"]'
       manylinux-platforms: '["_2_28-x64","2014-x64","_2_28-aarch64"]'
       test-notebooks: true
     secrets:


### PR DESCRIPTION
Python 3.12 and 3.13 now both have "bugfix" maintenance status, according to https://www.python.org/downloads/