### PR TITLE
BUG: Workaround "direction cosines matrix of the fixed image is invalid"

### DIFF
--- a/examples/ITK_Example06_GroupwiseRegistration.ipynb
+++ b/examples/ITK_Example06_GroupwiseRegistration.ipynb
@@ -36,10 +36,35 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Direction matrix before adjustment: itkMatrixD33 ([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]])\n",
+      "Direction matrix after adjustment: itkMatrixD33 ([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])\n"
+     ]
+    }
+   ],
    "source": [
     "# Load folder containing images.\n",
-    "images = itk.imread(\"data/00\", itk.F)"
+    "images = itk.imread(\"data/00\", itk.F)\n",
+    "\n",
+    "direction_matrix = itk.array_from_matrix(images.GetDirection())\n",
+    "if (direction_matrix.shape != (3, 3)\n",
+    "    or direction_matrix[0, 2] != 0.0\n",
+    "    or direction_matrix[1, 2] != 0.0\n",
+    "    or direction_matrix[2, 2] != 1.0\n",
+    "    or direction_matrix[2, 0] != 0.0\n",
+    "    or direction_matrix[2, 1] != 0.0):\n",
+    "    # The direction matrix must be of the form:\n",
+    "    #   [ . . 0 ]\n",
+    "    #   [ . . 0 ]\n",
+    "    #   [ 0 0 1 ]\n",
+    "    # If it isn't, just use the identity matrix.\n",
+    "    print(\"Direction matrix before adjustment:\", images.GetDirection())\n",
+    "    images.SetDirection(itk.Matrix[itk.D, 3, 3].GetIdentity())\n",
+    "    print(\"Direction matrix after adjustment:\", images.GetDirection())\n"
    ]
   },
   {


### PR DESCRIPTION
Set direction matrix to the identity matrix, as a workaround for issue https://github.com/InsightSoftwareConsortium/ITKElastix/issues/291 "GroupwiseRegistration notebook: ERROR: the direction cosines matrix of the fixed image is invalid!", reported by Matt McCormick (@thewtex) on May 23, 2024.


----

@ViktorvdValk Do you remember that you saw those error messages (as reported by issue #291) when you originally made this notebook? Otherwise I wonder how the errors "sneaked in" afterwards. Could `itk.imread("data/00", itk.F)` possibly have changed _after_ you made the notebook? 🤷 