### PR TITLE
ENH: Show conversion of TOML dict to elastix ParameterMap

### DIFF
--- a/examples/ITK_Example_TomlFileFormatForParameterFiles.ipynb
+++ b/examples/ITK_Example_TomlFileFormatForParameterFiles.ipynb
@@ -505,6 +505,86 @@
    "source": [
     "Summary, as shown by this notebook: elastix supports TOML files as input for registration parameters (via a `ParameterObject`) and (initial) transform parameters. It can also produce TOML files as output, when you specify the registration parameter `OutputTransformParameterFileFormat = \"TOML\"`. transformix supports TOML files as input for transform parameters."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee767dbf-4998-4c4c-bafa-56ecaa7fc14c",
+   "metadata": {},
+   "source": [
+    "## Bonus: How to convert a dict of TOML values to an elastix ParameterMap\n",
+    "\n",
+    "The following cell defines a utility function, `convert_to_parameter_map` to convert a TOML dict to a `ParameterMap`. It shows a little example, loading a TOML dict, converting the dict, and passing the result to a `ParameterObject`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5c53f8d7-8398-46e6-87e2-b2586eab9125",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'NumberOfParameters': 2, 'Transform': 'TranslationTransform', 'TransformParameters': [1.2345, -1048]}\n",
+      "ParameterObject (00000214E1672CF0)\n",
+      "  RTTI typeinfo:   class elastix::ParameterObject\n",
+      "  Reference Count: 1\n",
+      "  Modified Time: 2507\n",
+      "  Debug: Off\n",
+      "  Object Name: \n",
+      "  Observers: \n",
+      "    none\n",
+      "ParameterMap 0: \n",
+      "  (NumberOfParameters 2)\n",
+      "  (Transform \"TranslationTransform\")\n",
+      "  (TransformParameters 1.2345 -1048)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Converts a single TOML dict value (which may be a string, a bool, an integer, or a float) to an elastix parameter value (which is a string).\n",
+    "def convert_to_parameter_value(value) -> str:\n",
+    "    if isinstance(value, str):\n",
+    "        return value\n",
+    "    if isinstance(value, bool):\n",
+    "        # str(value) returns either \"True\" or \"False\", but elastix prefers lower-case.\n",
+    "        return \"true\" if value else \"false\"\n",
+    "    return str(value)\n",
+    "\n",
+    "\n",
+    "# Converts the specified \"TOML dict\" (which may be produced by tomllib) to a dict that is compatible with the elastix ParameterMap type:\n",
+    "# mapping strings to tuples of strings.\n",
+    "def convert_to_parameter_map(toml_dict: dict) -> dict:\n",
+    "    result = {}\n",
+    "    for key, value in toml_dict.items():\n",
+    "        if isinstance(value, (list, tuple)):\n",
+    "            result[key] = tuple(convert_to_parameter_value(item) for item in value)\n",
+    "        else:\n",
+    "            result[key] = (convert_to_parameter_value(value),)\n",
+    "    return result\n",
+    "\n",
+    "\n",
+    "# Example, trying out convert_to_parameter_map:\n",
+    "\n",
+    "toml_dict = tomllib.loads(\n",
+    "    \"\"\"\n",
+    "# Example transformation\n",
+    "NumberOfParameters = 2\n",
+    "Transform = \"TranslationTransform\"\n",
+    "TransformParameters = [ 1.2345, -1048 ]\n",
+    "\"\"\"\n",
+    ")\n",
+    "\n",
+    "print(toml_dict)\n",
+    "\n",
+    "parameter_object = itk.ParameterObject.New(\n",
+    "    parameter_map=convert_to_parameter_map(toml_dict)\n",
+    ")\n",
+    "\n",
+    "print(parameter_object)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Extended the TOML notebook, showing how to convert a Python `dict` from TOML to the elastix ParameterMap format.