### PR TITLE
COMP: Install playwright deps with pnpm exec instead of pnpx

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -31,8 +31,10 @@ jobs:
       with:
         node-version: '22'
         cache: pnpm
+
     - name: Install Playwright Browsers
-      run: pnpx playwright install --with-deps
+      working_directory: wasm/typescript
+      run: pnpm exec playwright install --with-deps
 
     - name: Build Typescript
       run: |


### PR DESCRIPTION
Obtain the same version used when testing.
