### PR TITLE
COMP: Replace `main` with `master` in yml files of ".github\workflows"

### DIFF
--- a/.github/workflows/apply-clang-format.yml
+++ b/.github/workflows/apply-clang-format.yml
@@ -10,6 +10,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: InsightSoftwareConsortium/ITKApplyClangFormatAction@master
+    - uses: InsightSoftwareConsortium/ITKApplyClangFormatAction@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -10,4 +10,4 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
-    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master
+    - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@main


### PR DESCRIPTION
Addressed a GitHub Action CI error from "lint", saying:

    Error: Unable to resolve action `insightsoftwareconsortium/itkclangformatlinteraction@master`, unable to find version `master`

- Following ITK pull request github.com/InsightSoftwareConsortium/ITK/pull/5426 "master to main"