### PR TITLE
COMP: Drop Python 3.9 (end of life)

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags')
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.3
     with:
-      python3-minor-versions: '["9","11"]'
+      python3-minor-versions: '["10","11"]'
       manylinux-platforms: '["_2_28-x64","2014-x64"]'
       test-notebooks: true
     secrets:
@@ -28,7 +28,7 @@ jobs:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.3
     with:
-      python3-minor-versions: '["9","10","11"]'
+      python3-minor-versions: '["10","11"]'
       manylinux-platforms: '["_2_28-x64","2014-x64"]'
       test-notebooks: true
     secrets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "itk~=5.4.3",
 ]


### PR DESCRIPTION
Python 3.9 is officially unsupported from 2025-10-31, according to https://devguide.python.org/versions/#unsupported-versions

- Followup to pull request #319