### PR TITLE
ENH: Bump CI to build against ITK 5.4.5 (dropping macos-13)

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   cxx:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.3
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.5
 
   py-dev:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags')
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.3
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
     with:
       python3-minor-versions: '["9","11"]'
       manylinux-platforms: '["_2_28-x64","2014-x64"]'
@@ -26,7 +26,7 @@ jobs:
 
   py-main:
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags')
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.3
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
     with:
       python3-minor-versions: '["9","10","11"]'
       manylinux-platforms: '["_2_28-x64","2014-x64"]'


### PR DESCRIPTION
ITKRemoteModuleBuildTestPackageAction v5.4.3 still uses macos-13, which is no longer supported.

ITKRemoteModuleBuildTestPackageAction v5.4.5 has dropped macos-13 with commit https://github.com/InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/commit/9b6e4e15b329ef1a98d87ced6e3ae3979f7638c5 (Matt McCormick, @thewtex, Nov 24, 2025)

Aims to address warnings at the CI (GitHub Actions), saying:

    The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more details see https://github.com/actions/runner-images/issues/13046