### PR TITLE
COMP: Remove CI manylinux platform constraints

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -19,7 +19,6 @@ jobs:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
     with:
       python3-minor-versions: '["10","11"]'
-      manylinux-platforms: '["_2_28-x64","2014-x64"]'
       test-notebooks: true
     secrets:
       pypi_password: ${{ secrets.pypi_password }}
@@ -29,7 +28,6 @@ jobs:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
     with:
       python3-minor-versions: '["10","11"]'
-      manylinux-platforms: '["_2_28-x64","2014-x64"]'
       test-notebooks: true
     secrets:
       pypi_password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
We previously disabled the ARM Linux builds because they took so long when they were built via emulation. There are now native ARM CI systems.

A workaround for:

```
Searching for wheels matching pattern dist/itk_*cp311*manylinux_2_28*aarch64.whl
ERROR    InvalidDistribution: Cannot find file (or expand pattern):
         'dist/itk_*cp311*manylinux_2_28*aarch64.whl'
```