### PR TITLE
COMP: Update matplotlib version to provide __version_info__

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -7,6 +7,6 @@ ipympl>=0.5.7
 numpy
 torch>=2.0
 monai>=1.3.0
-matplotlib==3.3.1
+matplotlib>=3.5.0
 voila
 tqdm


### PR DESCRIPTION
For:

File /opt/hostedtoolcache/Python/3.10.19/x64/lib/python3.10/site-packages/matplotlib_inline/backend_inline.py:215, in _enable_matplotlib_integration()
    211 ip = get_ipython()
    213 import matplotlib
--> 215 if matplotlib.__version_info__ >= (3, 10):
    216     backend = matplotlib.get_backend(auto_select=False)
    217 else:

AttributeError: module 'matplotlib' has no attribute '__version_info__'

matplotlib==3.3.1, is an older version that doesn't have the __version_info__ attribute. The matplotlib_inline package (used by Jupyter) is trying to use this attribute which was only added in matplotlib 3.5.0.

The __version_info__ attribute was added in matplotlib 3.5.0, so any version >= 3.5.0 will work with the matplotlib_inline package that Jupyter uses.