### PR TITLE
STYLE: Pass parameter_map directly to `ParameterObject.New` in examples

### DIFF
--- a/examples/ITK_Example01_SimpleRegistration.ipynb
+++ b/examples/ITK_Example01_SimpleRegistration.ipynb
@@ -65,9 +65,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parameter_object = itk.ParameterObject.New()\n",
     "default_rigid_parameter_map = itk.ParameterObject.GetDefaultParameterMap(\"rigid\")\n",
-    "parameter_object.AddParameterMap(default_rigid_parameter_map)"
+    "parameter_object = itk.ParameterObject.New(parameter_map=default_rigid_parameter_map)"
    ]
   },
   {

--- a/examples/ITK_Example04_InitialTransformAndMultiThreading.ipynb
+++ b/examples/ITK_Example04_InitialTransformAndMultiThreading.ipynb
@@ -49,9 +49,8 @@
     "moving_image = itk.imread(\"data/CT_2D_head_moving.mha\", itk.F)\n",
     "\n",
     "# Import Default Parameter Map\n",
-    "parameter_object = itk.ParameterObject.New()\n",
     "parameter_map_rigid = itk.ParameterObject.GetDefaultParameterMap(\"rigid\")\n",
-    "parameter_object.AddParameterMap(parameter_map_rigid)"
+    "parameter_object = itk.ParameterObject.New(parameter_map=parameter_map_rigid)"
    ]
   },
   {

--- a/examples/ITK_Example06_GroupwiseRegistration.ipynb
+++ b/examples/ITK_Example06_GroupwiseRegistration.ipynb
@@ -49,9 +49,8 @@
    "outputs": [],
    "source": [
     "# Create Groupwise Parameter Object\n",
-    "parameter_object = itk.ParameterObject.New()\n",
     "groupwise_parameter_map = itk.ParameterObject.GetDefaultParameterMap(\"groupwise\")\n",
-    "parameter_object.AddParameterMap(groupwise_parameter_map)"
+    "parameter_object = itk.ParameterObject.New(parameter_map=groupwise_parameter_map)"
    ]
   },
   {

--- a/examples/ITK_Example08_SimpleTransformix.ipynb
+++ b/examples/ITK_Example08_SimpleTransformix.ipynb
@@ -46,9 +46,8 @@
     "moving_image = itk.imread(\"data/CT_2D_head_moving.mha\", itk.F)\n",
     "\n",
     "# Import Default Parameter Map\n",
-    "parameter_object = itk.ParameterObject.New()\n",
     "parameter_map_rigid = itk.ParameterObject.GetDefaultParameterMap(\"rigid\")\n",
-    "parameter_object.AddParameterMap(parameter_map_rigid)"
+    "parameter_object = itk.ParameterObject.New(parameter_map=parameter_map_rigid)"
    ]
   },
   {

--- a/examples/ITK_Example10_Transformix_Jacobian.ipynb
+++ b/examples/ITK_Example10_Transformix_Jacobian.ipynb
@@ -44,9 +44,8 @@
     "moving_image = itk.imread(\"data/CT_2D_head_moving.mha\", itk.F)\n",
     "\n",
     "# Import Default Parameter Map\n",
-    "parameter_object = itk.ParameterObject.New()\n",
     "parameter_map_rigid = itk.ParameterObject.GetDefaultParameterMap(\"rigid\")\n",
-    "parameter_object.AddParameterMap(parameter_map_rigid)"
+    "parameter_object = itk.ParameterObject.New(parameter_map=parameter_map_rigid)"
    ]
   },
   {

--- a/examples/ITK_Example12_DifferentSizeTransformation.ipynb
+++ b/examples/ITK_Example12_DifferentSizeTransformation.ipynb
@@ -69,9 +69,8 @@
     "moving_image_dense = image_generator(0, 450, 100, 750)\n",
     "\n",
     "# Import Default Parameter Map\n",
-    "parameter_object = itk.ParameterObject.New()\n",
     "parameter_map_rigid = itk.ParameterObject.GetDefaultParameterMap(\"affine\")\n",
-    "parameter_object.AddParameterMap(parameter_map_rigid)"
+    "parameter_object = itk.ParameterObject.New(parameter_map=parameter_map_rigid)"
    ]
   },
   {

--- a/examples/ITK_Example15_Transformix_image_TranslationTransform.ipynb
+++ b/examples/ITK_Example15_Transformix_image_TranslationTransform.ipynb
@@ -136,8 +136,7 @@
     }
    ],
    "source": [
-    "parameter_object = itk.ParameterObject.New()\n",
-    "parameter_object.AddParameterMap(parameter_map)\n",
+    "parameter_object = itk.ParameterObject.New(parameter_map=parameter_map)\n",
     "\n",
     "transformix_filter.SetMovingImage(moving_image)\n",
     "transformix_filter.SetTransformParameterObject(parameter_object)\n",

--- a/examples/ITK_Example16_Transformix_mesh_TranslationTransform.ipynb
+++ b/examples/ITK_Example16_Transformix_mesh_TranslationTransform.ipynb
@@ -129,8 +129,7 @@
     }
    ],
    "source": [
-    "parameter_object = itk.ParameterObject.New()\n",
-    "parameter_object.AddParameterMap(parameter_map)\n",
+    "parameter_object = itk.ParameterObject.New(parameter_map=parameter_map)\n",
     "\n",
     "transformix_filter.SetMovingImage(moving_image)\n",
     "transformix_filter.SetTransformParameterObject(parameter_object)\n",

--- a/examples/ITK_UnitTestExample1_RigidRegistration.ipynb
+++ b/examples/ITK_UnitTestExample1_RigidRegistration.ipynb
@@ -58,9 +58,8 @@
     "moving_image = image_generator(1, 51, 10, 60)\n",
     "\n",
     "# Import Default Parameter Map\n",
-    "parameter_object = itk.ParameterObject.New()\n",
     "default_rigid_parameter_map = itk.ParameterObject.GetDefaultParameterMap(\"rigid\")\n",
-    "parameter_object.AddParameterMap(default_rigid_parameter_map)"
+    "parameter_object = itk.ParameterObject.New(parameter_map=default_rigid_parameter_map)"
    ]
   },
   {

--- a/examples/ITK_UnitTestExample2_AffineRegistration.ipynb
+++ b/examples/ITK_UnitTestExample2_AffineRegistration.ipynb
@@ -58,10 +58,9 @@
     "moving_image_affine = image_generator(1, 71, 1, 91)\n",
     "\n",
     "# Import Default Parameter Map\n",
-    "parameter_object = itk.ParameterObject.New()\n",
     "default_affine_parameter_map = itk.ParameterObject.GetDefaultParameterMap(\"affine\", 4)\n",
     "default_affine_parameter_map[\"FinalBSplineInterpolationOrder\"] = [\"0\"]\n",
-    "parameter_object.AddParameterMap(default_affine_parameter_map)"
+    "parameter_object = itk.ParameterObject.New(parameter_map=default_affine_parameter_map)"
    ]
   },
   {


### PR DESCRIPTION
Demonstrated the shorter form of initializing a ParameterObject by a map, as in:

    parameter_object = itk.ParameterObject.New(parameter_map=default_rigid_parameter_map)