### PR TITLE
COMP: Update binder matplotlib

### DIFF
--- a/.binder/requirements.txt
+++ b/.binder/requirements.txt
@@ -1,4 +1,4 @@
-itk-elastix>=0.17.3
+itk-elastix>=0.19.1
 itkwidgets>=0.32.0
 jupyterlab>=2.2.0
 imageio
@@ -6,8 +6,8 @@ ipywidgets>=7.5.1
 ipympl>=0.5.7
 numpy
 torch>=2.0
-monai>=1.2.0
-matplotlib==3.3.1
+monai>=1.3.0
+matplotlib>=3.5.0
 PyQt5==5.15.0
 PyQt5-sip==12.8.0
 QtPy==1.9.0


### PR DESCRIPTION
And monai and itk-elastix to be consistent with
examples/requirements.txt.

To address binder build where matplotlib fails to build from source. Similar to https://github.com/InsightSoftwareConsortium/ITKElastix/pull/359 Update the matplotlib version so pre-built packages are available.