### PR TITLE
BUG: Correct wasm GitHub Action CI working directory syntax

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -27,6 +27,9 @@ jobs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
+      with:
+        run_install: true
+
     - uses: actions/setup-node@v4
       with:
         node-version: '22'


### PR DESCRIPTION
The correct syntax is "working-directory" instead of "working_directory".