### PR TITLE
ENH: Bump Python package version to 0.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-elastix"
-version = "0.23.0"
+version = "0.24.0"
 description = "Provides an ITK Python interface to elastix, a toolbox for rigid and nonrigid registration of images"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Using the latest elastix release, version 5.3.0.

----

Suggested by Matt McCormick (@thewtex) at https://github.com/InsightSoftwareConsortium/ITKElastix/pull/363#issuecomment-3855265127