### PR TITLE
ENH: Use itk_module_target of elastix libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,11 +112,17 @@ if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
+
   if(WASI OR EMSCRIPTEN OR ITKELASTIX_BUILD_WASM_EXECUTABLES)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     add_subdirectory(wasm)
   endif()
 else()
   set(ITK_DIR ${CMAKE_BINARY_DIR})
+
   itk_module_impl()
 endif()
+
+# ITK version 6.0+ requires exported targets for used libraries
+itk_module_target(elastix_lib NO_INSTALL)
+itk_module_target(transformix_lib NO_INSTALL)

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -26,7 +26,6 @@ itk_module(Elastix
   TEST_DEPENDS
     ITKTestKernel
     ITKMetaIO
-    ITKTransformIO
   DESCRIPTION
     "${DOCUMENTATION}"
   EXCLUDE_FROM_DEFAULT


### PR DESCRIPTION
Addresses compilation error when building just the C++ library against ITKv6:

```
CMake Error at /Users/svc-dashboard/D/P/ITKPythonPackage/ITK-source/ITK/CMake/ITKModuleMacros.cmake:378 (target_link_libraries):
  The link interface of target "ElastixModule" contains:

    ITK::elastix_lib
```