### PR TITLE
PERF: Upgrade elastix to 2026-05-15 (faster AfterThreadedComputePDFs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ if(WASI OR EMSCRIPTEN)
 endif()
 
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-# Upstream tag 5.3.1, 2026-03-17
-set(elastix_GIT_TAG "ef34ca99d84c226d1bb72d534c8a201526a5c034")
+# Upstream "PERF: Preallocate Parzen PDF values outside of for-each-sample loops", 2026-05-15
+set(elastix_GIT_TAG "77c726adda9bbc12d9996f493ebe73f3e26b6b97")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}


### PR DESCRIPTION
Included elastix pull requests:
- https://github.com/SuperElastix/elastix/pull/1440
- https://github.com/SuperElastix/elastix/pull/1431

All included new commits:

https://github.com/SuperElastix/elastix/compare/5.3.1...77c726adda9bbc12d9996f493ebe73f3e26b6b97