### PR TITLE
ENH: ITKRemoteModuleBuildTestPackageAction build-test-cxx.yml@v5.4.6

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   cxx:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.5
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
 
   py-dev:
     if: github.ref != 'refs/heads/master' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
Using ITKRemoteModuleBuildTestPackageAction branch v5.4.6 for build-test-cxx.yml just like for build-test-package-python.yml and build-test-package-python.yml.

- Follow-up to pull request #385 by Matt McCormick (@thewtex)