### PR TITLE
ENH: Upgrade elastix to 2026-07-09 (ITK6 modern CMake library targets)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ if(WASI OR EMSCRIPTEN)
 endif()
 
 set(elastix_GIT_REPOSITORY "https://github.com/SuperElastix/elastix.git")
-# Upstream "COMP: Use itk::Math::MatrixExponential instead of removed vnl_matrix_exp", 2026-06-23
-set(elastix_GIT_TAG "b554847140dee197d0a06c37203025d9dcc50936")
+# Upstream "STYLE: Add PUBLIC to target_link_libraries and elastix_link_itk calls", 2026-07-09
+set(elastix_GIT_TAG "5c71a233ffebfb52e80945dae1bc07db0290be3c")
 FetchContent_Declare(
   elx
   GIT_REPOSITORY ${elastix_GIT_REPOSITORY}


### PR DESCRIPTION
Including pull request https://github.com/SuperElastix/elastix/pull/1435 commit https://github.com/SuperElastix/elastix/commit/5b50b8f49fa923e944bd294f0b751fd280597e97 by Bradley Lowekamp (@blowekamp)

Following SimpleITK pull request https://github.com/SimpleITK/SimpleITK/pull/2623 commit https://github.com/SimpleITK/SimpleITK/commit/3e193179e1cfc2dd3ee4ec26a4827df0802ea05b